### PR TITLE
feat: add 6 core plugin interfaces (#2)

### DIFF
--- a/src/main/java/com/visa/nucleus/core/AgentSession.java
+++ b/src/main/java/com/visa/nucleus/core/AgentSession.java
@@ -1,0 +1,16 @@
+package com.visa.nucleus.core;
+
+/**
+ * Represents an active agent session. Placeholder — full implementation in a separate issue.
+ */
+public class AgentSession {
+    private final String sessionId;
+
+    public AgentSession(String sessionId) {
+        this.sessionId = sessionId;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+}

--- a/src/main/java/com/visa/nucleus/core/plugin/AgentPlugin.java
+++ b/src/main/java/com/visa/nucleus/core/plugin/AgentPlugin.java
@@ -1,0 +1,9 @@
+package com.visa.nucleus.core.plugin;
+
+import com.visa.nucleus.core.AgentSession;
+
+public interface AgentPlugin {
+    void initialize(AgentSession session, String issueContext) throws Exception;
+    void sendMessage(String sessionId, String message) throws Exception;
+    String getAgentType();
+}

--- a/src/main/java/com/visa/nucleus/core/plugin/NotificationLevel.java
+++ b/src/main/java/com/visa/nucleus/core/plugin/NotificationLevel.java
@@ -1,0 +1,7 @@
+package com.visa.nucleus.core.plugin;
+
+public enum NotificationLevel {
+    INFO,
+    NEEDS_ATTENTION,
+    READY_TO_MERGE
+}

--- a/src/main/java/com/visa/nucleus/core/plugin/NotifierPlugin.java
+++ b/src/main/java/com/visa/nucleus/core/plugin/NotifierPlugin.java
@@ -1,0 +1,5 @@
+package com.visa.nucleus.core.plugin;
+
+public interface NotifierPlugin {
+    void notify(String sessionId, String message, NotificationLevel level) throws Exception;
+}

--- a/src/main/java/com/visa/nucleus/core/plugin/RuntimePlugin.java
+++ b/src/main/java/com/visa/nucleus/core/plugin/RuntimePlugin.java
@@ -1,0 +1,11 @@
+package com.visa.nucleus.core.plugin;
+
+import com.visa.nucleus.core.AgentSession;
+
+public interface RuntimePlugin {
+    void start(AgentSession session) throws Exception;
+    void stop(String sessionId) throws Exception;
+    void sendInstruction(String sessionId, String instruction) throws Exception;
+    String getLogs(String sessionId) throws Exception;
+    boolean isRunning(String sessionId);
+}

--- a/src/main/java/com/visa/nucleus/core/plugin/ScmPlugin.java
+++ b/src/main/java/com/visa/nucleus/core/plugin/ScmPlugin.java
@@ -1,0 +1,10 @@
+package com.visa.nucleus.core.plugin;
+
+import java.util.List;
+
+public interface ScmPlugin {
+    String createPullRequest(String branch, String title, String body) throws Exception;
+    List<String> getReviewComments(String prUrl) throws Exception;
+    String getCiLogs(String prUrl) throws Exception;
+    void replyToComment(String commentId, String reply) throws Exception;
+}

--- a/src/main/java/com/visa/nucleus/core/plugin/TrackerPlugin.java
+++ b/src/main/java/com/visa/nucleus/core/plugin/TrackerPlugin.java
@@ -1,0 +1,7 @@
+package com.visa.nucleus.core.plugin;
+
+public interface TrackerPlugin {
+    String getIssueContext(String ticketId) throws Exception;
+    void addComment(String ticketId, String comment) throws Exception;
+    void transitionStatus(String ticketId, String toStatus) throws Exception;
+}

--- a/src/main/java/com/visa/nucleus/core/plugin/WorkspacePlugin.java
+++ b/src/main/java/com/visa/nucleus/core/plugin/WorkspacePlugin.java
@@ -1,0 +1,7 @@
+package com.visa.nucleus.core.plugin;
+
+public interface WorkspacePlugin {
+    String createWorktree(String repoPath, String branchName) throws Exception;
+    void deleteWorktree(String worktreePath) throws Exception;
+    String generateBranchName(String ticketId, String ticketTitle);
+}


### PR DESCRIPTION
## Summary

- Creates all 6 plugin interfaces under `com.visa.nucleus.core.plugin`
- Adds `NotificationLevel` enum (INFO, NEEDS_ATTENTION, READY_TO_MERGE)
- Adds minimal `AgentSession` stub in `com.visa.nucleus.core` to satisfy compile-time imports

## Interfaces added

| Interface | Responsibility |
|---|---|
| `RuntimePlugin` | Start/stop agent sessions, send instructions, fetch logs |
| `AgentPlugin` | Initialize agent with issue context, send messages |
| `WorkspacePlugin` | Git worktree lifecycle and branch name generation |
| `TrackerPlugin` | Issue context retrieval, comments, status transitions |
| `ScmPlugin` | PR creation, review comments, CI logs, comment replies |
| `NotifierPlugin` | Session-scoped notifications with severity level |

## Test plan
- [ ] Verify all interfaces compile cleanly with `javac`
- [ ] Confirm package names match `com.visa.nucleus.core.plugin`
- [ ] Verify `NotificationLevel` enum contains INFO, NEEDS_ATTENTION, READY_TO_MERGE

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)