### PR TITLE
feat: implement GitWorktreePlugin and ProcessRunner

### DIFF
--- a/src/main/java/com/visa/nucleus/plugins/workspace/GitWorktreePlugin.java
+++ b/src/main/java/com/visa/nucleus/plugins/workspace/GitWorktreePlugin.java
@@ -1,0 +1,59 @@
+package com.visa.nucleus.plugins.workspace;
+
+import com.visa.nucleus.core.plugin.WorkspacePlugin;
+
+import java.io.File;
+import java.util.List;
+
+public class GitWorktreePlugin implements WorkspacePlugin {
+
+    private static final String WORKTREE_BASE = "/tmp/nucleus-worktrees/";
+
+    private final ProcessRunner processRunner;
+
+    public GitWorktreePlugin() {
+        this.processRunner = new ProcessRunner();
+    }
+
+    // Package-private for testing
+    GitWorktreePlugin(ProcessRunner processRunner) {
+        this.processRunner = processRunner;
+    }
+
+    @Override
+    public String createWorktree(String repoPath, String branchName) throws Exception {
+        File worktreeBase = new File(WORKTREE_BASE);
+        if (!worktreeBase.exists()) {
+            worktreeBase.mkdirs();
+        }
+
+        String worktreePath = WORKTREE_BASE + branchName;
+        processRunner.run(
+            List.of("git", "worktree", "add", "-b", branchName, worktreePath, "HEAD"),
+            repoPath
+        );
+        return worktreePath;
+    }
+
+    @Override
+    public void deleteWorktree(String worktreePath) throws Exception {
+        // Use the parent repo path — git worktree remove can be run from any git dir.
+        // We derive the repo by walking up from the worktree path, but since the
+        // worktree may not be a standard repo dir we just use the worktree path itself
+        // as the working directory; git resolves the main repo via .git metadata.
+        processRunner.run(
+            List.of("git", "worktree", "remove", worktreePath, "--force"),
+            worktreePath
+        );
+    }
+
+    @Override
+    public String generateBranchName(String ticketId, String ticketTitle) {
+        String slug = ticketTitle
+            .toLowerCase()
+            .replaceAll("[^a-z0-9\\s-]", "")
+            .trim()
+            .replaceAll("\\s+", "-");
+        return "feat/" + ticketId + "-" + slug;
+    }
+}

--- a/src/main/java/com/visa/nucleus/plugins/workspace/ProcessRunner.java
+++ b/src/main/java/com/visa/nucleus/plugins/workspace/ProcessRunner.java
@@ -1,0 +1,32 @@
+package com.visa.nucleus.plugins.workspace;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ProcessRunner {
+
+    public String run(List<String> command, String workingDir) throws IOException, InterruptedException {
+        ProcessBuilder pb = new ProcessBuilder(command);
+        pb.directory(new File(workingDir));
+        pb.redirectErrorStream(true);
+
+        Process process = pb.start();
+        String output;
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            output = reader.lines().collect(Collectors.joining(System.lineSeparator()));
+        }
+
+        int exitCode = process.waitFor();
+        if (exitCode != 0) {
+            throw new RuntimeException(
+                "Command failed with exit code " + exitCode + ": " + String.join(" ", command) +
+                (output.isEmpty() ? "" : "\nOutput: " + output)
+            );
+        }
+        return output;
+    }
+}

--- a/src/test/java/com/visa/nucleus/plugins/workspace/GitWorktreePluginTest.java
+++ b/src/test/java/com/visa/nucleus/plugins/workspace/GitWorktreePluginTest.java
@@ -1,0 +1,75 @@
+package com.visa.nucleus.plugins.workspace;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GitWorktreePluginTest {
+
+    @Mock
+    private ProcessRunner processRunner;
+
+    private GitWorktreePlugin plugin;
+
+    @BeforeEach
+    void setUp() {
+        plugin = new GitWorktreePlugin(processRunner);
+    }
+
+    @Test
+    void createWorktree_invokesGitWorktreeAdd() throws Exception {
+        String repoPath = "/some/repo";
+        String branchName = "feat/JIRA-1-my-feature";
+        String expectedPath = "/tmp/nucleus-worktrees/" + branchName;
+
+        when(processRunner.run(any(), eq(repoPath))).thenReturn("");
+
+        String result = plugin.createWorktree(repoPath, branchName);
+
+        assertEquals(expectedPath, result);
+        verify(processRunner).run(
+            eq(List.of("git", "worktree", "add", "-b", branchName, expectedPath, "HEAD")),
+            eq(repoPath)
+        );
+    }
+
+    @Test
+    void deleteWorktree_invokesGitWorktreeRemove() throws Exception {
+        String worktreePath = "/tmp/nucleus-worktrees/feat/JIRA-1-my-feature";
+
+        plugin.deleteWorktree(worktreePath);
+
+        verify(processRunner).run(
+            eq(List.of("git", "worktree", "remove", worktreePath, "--force")),
+            eq(worktreePath)
+        );
+    }
+
+    @Test
+    void generateBranchName_slugifiesTitle() {
+        assertEquals("feat/JIRA-421-add-lf-tag-governance",
+            plugin.generateBranchName("JIRA-421", "Add LF Tag Governance"));
+    }
+
+    @Test
+    void generateBranchName_removesSpecialChars() {
+        assertEquals("feat/JIRA-1-fix-bug-with-api",
+            plugin.generateBranchName("JIRA-1", "Fix bug with API!!!"));
+    }
+
+    @Test
+    void generateBranchName_collapsesWhitespace() {
+        assertEquals("feat/JIRA-2-update-readme",
+            plugin.generateBranchName("JIRA-2", "  Update   README  "));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ProcessRunner` utility that wraps `ProcessBuilder`, executes a command list in a working directory, and throws `RuntimeException` on non-zero exit
- Add `GitWorktreePlugin` implementing `WorkspacePlugin` via `ProcessRunner`:
  - `createWorktree` — runs `git worktree add -b <branch> /tmp/nucleus-worktrees/<branch> HEAD`, auto-creates base dir, returns worktree path
  - `deleteWorktree` — runs `git worktree remove <path> --force`
  - `generateBranchName` — slugifies ticket title (lowercase, spaces→hyphens, special chars stripped) and returns `feat/<ticketId>-<slug>`
- Unit tests with Mockito for all three plugin methods

## Notes

The repo has no Maven/Gradle build file yet (the Dockerfile references `./mvnw` which is absent). Tests are written with JUnit 5 + Mockito and will pass once a build system is wired up.

## Test plan

- [ ] Add `pom.xml` / `mvnw` to the repo so `./mvnw test` can be run
- [ ] `GitWorktreePluginTest` covers `createWorktree`, `deleteWorktree`, and `generateBranchName` — all should pass

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)