### PR TITLE
feat: implement ClaudeAgentPlugin and OpenAIAgentPlugin (#7)

### DIFF
--- a/src/main/java/com/visa/nucleus/plugins/agent/AgentPluginFactory.java
+++ b/src/main/java/com/visa/nucleus/plugins/agent/AgentPluginFactory.java
@@ -1,0 +1,28 @@
+package com.visa.nucleus.plugins.agent;
+
+import com.visa.nucleus.core.plugin.AgentPlugin;
+
+/**
+ * Factory that returns the appropriate AgentPlugin implementation based on the requested agent type.
+ */
+public class AgentPluginFactory {
+
+    /**
+     * Returns an AgentPlugin for the given agent type.
+     *
+     * @param agentType "claude" for ClaudeAgentPlugin, "openai" for OpenAIAgentPlugin
+     * @return the matching AgentPlugin
+     * @throws IllegalArgumentException if the agent type is not supported
+     */
+    public AgentPlugin create(String agentType) {
+        if (agentType == null) {
+            throw new IllegalArgumentException("agentType must not be null");
+        }
+        switch (agentType.toLowerCase()) {
+            case "claude": return new ClaudeAgentPlugin();
+            case "openai": return new OpenAIAgentPlugin();
+            default:
+                throw new IllegalArgumentException("Unsupported agent type: " + agentType);
+        }
+    }
+}

--- a/src/main/java/com/visa/nucleus/plugins/agent/ClaudeAgentPlugin.java
+++ b/src/main/java/com/visa/nucleus/plugins/agent/ClaudeAgentPlugin.java
@@ -1,0 +1,158 @@
+package com.visa.nucleus.plugins.agent;
+
+import com.visa.nucleus.core.AgentSession;
+import com.visa.nucleus.core.plugin.AgentPlugin;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * AgentPlugin implementation that sends messages to the Anthropic Claude API.
+ *
+ * Configuration:
+ *   nucleus.agent.anthropic.apiKey  — set via environment variable ANTHROPIC_API_KEY
+ *   nucleus.agent.anthropic.model   — default: claude-sonnet-4-6
+ */
+public class ClaudeAgentPlugin implements AgentPlugin {
+
+    static final String DEFAULT_MODEL = "claude-sonnet-4-6";
+    static final String API_URL = "https://api.anthropic.com/v1/messages";
+    static final String API_VERSION = "2023-06-01";
+
+    private final String apiKey;
+    private final String model;
+    private final HttpClient httpClient;
+
+    /** sessionId -> system prompt */
+    private final Map<String, String> systemPrompts = new ConcurrentHashMap<>();
+    /** sessionId -> ordered list of {role, content} message pairs */
+    private final Map<String, List<String[]>> conversations = new ConcurrentHashMap<>();
+
+    public ClaudeAgentPlugin() {
+        this(System.getenv("ANTHROPIC_API_KEY"), DEFAULT_MODEL, HttpClient.newHttpClient());
+    }
+
+    // Package-private constructor for testing
+    ClaudeAgentPlugin(String apiKey, String model, HttpClient httpClient) {
+        this.apiKey = apiKey;
+        this.model = model != null ? model : DEFAULT_MODEL;
+        this.httpClient = httpClient;
+    }
+
+    @Override
+    public String getAgentType() {
+        return "claude";
+    }
+
+    @Override
+    public void initialize(AgentSession session, String issueContext) throws Exception {
+        if (apiKey == null || apiKey.isBlank()) {
+            throw new IllegalStateException(
+                "Anthropic API key is not configured. Set ANTHROPIC_API_KEY environment variable.");
+        }
+
+        String sessionId = session.getSessionId();
+        String systemPrompt = buildSystemPrompt(issueContext, sessionId);
+        systemPrompts.put(sessionId, systemPrompt);
+        conversations.put(sessionId, new ArrayList<>());
+
+        sendMessage(sessionId, "Begin. Review the issue context and confirm you are ready to start.");
+    }
+
+    @Override
+    public void sendMessage(String sessionId, String message) throws Exception {
+        String systemPrompt = systemPrompts.get(sessionId);
+        if (systemPrompt == null) {
+            throw new IllegalStateException("Session not initialized: " + sessionId);
+        }
+
+        List<String[]> history = conversations.get(sessionId);
+        history.add(new String[]{"user", message});
+
+        String requestBody = buildRequestBody(systemPrompt, history);
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(API_URL))
+                .header("Content-Type", "application/json")
+                .header("x-api-key", apiKey)
+                .header("anthropic-version", API_VERSION)
+                .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+                .build();
+
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            throw new RuntimeException(
+                "Anthropic API returned non-success status: " + response.statusCode()
+                + " body: " + response.body());
+        }
+
+        String assistantReply = extractTextFromResponse(response.body());
+        history.add(new String[]{"assistant", assistantReply});
+    }
+
+    private String buildSystemPrompt(String issueContext, String sessionId) {
+        String ticketId = extractTicketId(sessionId);
+        return "You are an autonomous coding agent working on: " + issueContext + "\n"
+            + "Repository is at /workspace. You have full access to read and write files.\n"
+            + "When done, create a commit with message: feat(" + ticketId + "): {summary}";
+    }
+
+    private String extractTicketId(String sessionId) {
+        // Best-effort extraction of a ticket ID from sessionId (e.g. "PROJ-123-abc" -> "PROJ-123")
+        if (sessionId == null) return "unknown";
+        String[] parts = sessionId.split("-");
+        if (parts.length >= 2) {
+            return parts[0] + "-" + parts[1];
+        }
+        return sessionId;
+    }
+
+    private String buildRequestBody(String systemPrompt, List<String[]> history) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{");
+        sb.append("\"model\":\"").append(escapeJson(model)).append("\",");
+        sb.append("\"max_tokens\":4096,");
+        sb.append("\"system\":\"").append(escapeJson(systemPrompt)).append("\",");
+        sb.append("\"messages\":[");
+        for (int i = 0; i < history.size(); i++) {
+            String[] entry = history.get(i);
+            if (i > 0) sb.append(",");
+            sb.append("{\"role\":\"").append(entry[0]).append("\",")
+              .append("\"content\":\"").append(escapeJson(entry[1])).append("\"}");
+        }
+        sb.append("]}");
+        return sb.toString();
+    }
+
+    // Minimal extraction of the first text block from the Anthropic response JSON
+    String extractTextFromResponse(String responseBody) {
+        String marker = "\"text\":\"";
+        int start = responseBody.indexOf(marker);
+        if (start == -1) return "";
+        start += marker.length();
+        StringBuilder result = new StringBuilder();
+        for (int i = start; i < responseBody.length(); i++) {
+            char c = responseBody.charAt(i);
+            if (c == '"' && (i == start || responseBody.charAt(i - 1) != '\\')) break;
+            result.append(c);
+        }
+        return result.toString().replace("\\n", "\n").replace("\\\"", "\"").replace("\\\\", "\\");
+    }
+
+    private String escapeJson(String value) {
+        if (value == null) return "";
+        return value
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\t", "\\t");
+    }
+}

--- a/src/main/java/com/visa/nucleus/plugins/agent/OpenAIAgentPlugin.java
+++ b/src/main/java/com/visa/nucleus/plugins/agent/OpenAIAgentPlugin.java
@@ -1,0 +1,153 @@
+package com.visa.nucleus.plugins.agent;
+
+import com.visa.nucleus.core.AgentSession;
+import com.visa.nucleus.core.plugin.AgentPlugin;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * AgentPlugin implementation that sends messages to the OpenAI Chat Completions API.
+ *
+ * Configuration:
+ *   nucleus.agent.openai.apiKey — set via environment variable OPENAI_API_KEY
+ *   nucleus.agent.openai.model  — default: gpt-4o
+ */
+public class OpenAIAgentPlugin implements AgentPlugin {
+
+    static final String DEFAULT_MODEL = "gpt-4o";
+    static final String API_URL = "https://api.openai.com/v1/chat/completions";
+
+    private final String apiKey;
+    private final String model;
+    private final HttpClient httpClient;
+
+    /** sessionId -> system prompt */
+    private final Map<String, String> systemPrompts = new ConcurrentHashMap<>();
+    /** sessionId -> ordered list of {role, content} message pairs */
+    private final Map<String, List<String[]>> conversations = new ConcurrentHashMap<>();
+
+    public OpenAIAgentPlugin() {
+        this(System.getenv("OPENAI_API_KEY"), DEFAULT_MODEL, HttpClient.newHttpClient());
+    }
+
+    // Package-private constructor for testing
+    OpenAIAgentPlugin(String apiKey, String model, HttpClient httpClient) {
+        this.apiKey = apiKey;
+        this.model = model != null ? model : DEFAULT_MODEL;
+        this.httpClient = httpClient;
+    }
+
+    @Override
+    public String getAgentType() {
+        return "openai";
+    }
+
+    @Override
+    public void initialize(AgentSession session, String issueContext) throws Exception {
+        if (apiKey == null || apiKey.isBlank()) {
+            throw new IllegalStateException(
+                "OpenAI API key is not configured. Set OPENAI_API_KEY environment variable.");
+        }
+
+        String sessionId = session.getSessionId();
+        String systemPrompt = buildSystemPrompt(issueContext, sessionId);
+        systemPrompts.put(sessionId, systemPrompt);
+        conversations.put(sessionId, new ArrayList<>());
+
+        sendMessage(sessionId, "Begin. Review the issue context and confirm you are ready to start.");
+    }
+
+    @Override
+    public void sendMessage(String sessionId, String message) throws Exception {
+        String systemPrompt = systemPrompts.get(sessionId);
+        if (systemPrompt == null) {
+            throw new IllegalStateException("Session not initialized: " + sessionId);
+        }
+
+        List<String[]> history = conversations.get(sessionId);
+        history.add(new String[]{"user", message});
+
+        String requestBody = buildRequestBody(systemPrompt, history);
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(API_URL))
+                .header("Content-Type", "application/json")
+                .header("Authorization", "Bearer " + apiKey)
+                .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+                .build();
+
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            throw new RuntimeException(
+                "OpenAI API returned non-success status: " + response.statusCode()
+                + " body: " + response.body());
+        }
+
+        String assistantReply = extractContentFromResponse(response.body());
+        history.add(new String[]{"assistant", assistantReply});
+    }
+
+    private String buildSystemPrompt(String issueContext, String sessionId) {
+        String ticketId = extractTicketId(sessionId);
+        return "You are an autonomous coding agent working on: " + issueContext + "\n"
+            + "Repository is at /workspace. You have full access to read and write files.\n"
+            + "When done, create a commit with message: feat(" + ticketId + "): {summary}";
+    }
+
+    private String extractTicketId(String sessionId) {
+        if (sessionId == null) return "unknown";
+        String[] parts = sessionId.split("-");
+        if (parts.length >= 2) {
+            return parts[0] + "-" + parts[1];
+        }
+        return sessionId;
+    }
+
+    private String buildRequestBody(String systemPrompt, List<String[]> history) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{");
+        sb.append("\"model\":\"").append(escapeJson(model)).append("\",");
+        sb.append("\"messages\":[");
+        // System message first
+        sb.append("{\"role\":\"system\",\"content\":\"").append(escapeJson(systemPrompt)).append("\"}");
+        for (String[] entry : history) {
+            sb.append(",{\"role\":\"").append(entry[0]).append("\",")
+              .append("\"content\":\"").append(escapeJson(entry[1])).append("\"}");
+        }
+        sb.append("]}");
+        return sb.toString();
+    }
+
+    // Minimal extraction of the assistant content from the OpenAI response JSON
+    String extractContentFromResponse(String responseBody) {
+        String marker = "\"content\":\"";
+        int start = responseBody.indexOf(marker);
+        if (start == -1) return "";
+        start += marker.length();
+        StringBuilder result = new StringBuilder();
+        for (int i = start; i < responseBody.length(); i++) {
+            char c = responseBody.charAt(i);
+            if (c == '"' && (i == start || responseBody.charAt(i - 1) != '\\')) break;
+            result.append(c);
+        }
+        return result.toString().replace("\\n", "\n").replace("\\\"", "\"").replace("\\\\", "\\");
+    }
+
+    private String escapeJson(String value) {
+        if (value == null) return "";
+        return value
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\t", "\\t");
+    }
+}

--- a/src/test/java/com/visa/nucleus/plugins/agent/AgentPluginFactoryTest.java
+++ b/src/test/java/com/visa/nucleus/plugins/agent/AgentPluginFactoryTest.java
@@ -1,0 +1,41 @@
+package com.visa.nucleus.plugins.agent;
+
+import com.visa.nucleus.core.plugin.AgentPlugin;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AgentPluginFactoryTest {
+
+    private final AgentPluginFactory factory = new AgentPluginFactory();
+
+    @Test
+    void create_returnsClaude() {
+        AgentPlugin plugin = factory.create("claude");
+        assertInstanceOf(ClaudeAgentPlugin.class, plugin);
+        assertEquals("claude", plugin.getAgentType());
+    }
+
+    @Test
+    void create_returnsOpenAI() {
+        AgentPlugin plugin = factory.create("openai");
+        assertInstanceOf(OpenAIAgentPlugin.class, plugin);
+        assertEquals("openai", plugin.getAgentType());
+    }
+
+    @Test
+    void create_isCaseInsensitive() {
+        assertInstanceOf(ClaudeAgentPlugin.class, factory.create("Claude"));
+        assertInstanceOf(OpenAIAgentPlugin.class, factory.create("OpenAI"));
+    }
+
+    @Test
+    void create_throwsForUnknownType() {
+        assertThrows(IllegalArgumentException.class, () -> factory.create("gemini"));
+    }
+
+    @Test
+    void create_throwsForNull() {
+        assertThrows(IllegalArgumentException.class, () -> factory.create(null));
+    }
+}

--- a/src/test/java/com/visa/nucleus/plugins/agent/ClaudeAgentPluginTest.java
+++ b/src/test/java/com/visa/nucleus/plugins/agent/ClaudeAgentPluginTest.java
@@ -1,0 +1,116 @@
+package com.visa.nucleus.plugins.agent;
+
+import com.visa.nucleus.core.AgentSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class ClaudeAgentPluginTest {
+
+    private HttpClient httpClient;
+    @SuppressWarnings("unchecked")
+    private HttpResponse<String> httpResponse = (HttpResponse<String>) mock(HttpResponse.class);
+    private ClaudeAgentPlugin plugin;
+
+    @BeforeEach
+    void setUp() {
+        httpClient = mock(HttpClient.class);
+        plugin = new ClaudeAgentPlugin("test-api-key", ClaudeAgentPlugin.DEFAULT_MODEL, httpClient);
+    }
+
+    @Test
+    void getAgentType_returnsClaude() {
+        assertEquals("claude", plugin.getAgentType());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void initialize_sendsFirstMessage() throws Exception {
+        when(httpResponse.statusCode()).thenReturn(200);
+        when(httpResponse.body()).thenReturn(buildAnthropicResponse("Ready to start."));
+        doReturn(httpResponse).when(httpClient).send(any(HttpRequest.class), any());
+
+        AgentSession session = new AgentSession("PROJ-42-abc");
+        plugin.initialize(session, "Implement feature X");
+
+        verify(httpClient, times(1)).send(any(HttpRequest.class), any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void sendMessage_appendsToConversationHistory() throws Exception {
+        when(httpResponse.statusCode()).thenReturn(200);
+        when(httpResponse.body())
+                .thenReturn(buildAnthropicResponse("Ready."))
+                .thenReturn(buildAnthropicResponse("Done."));
+        doReturn(httpResponse).when(httpClient).send(any(HttpRequest.class), any());
+
+        AgentSession session = new AgentSession("PROJ-10-xyz");
+        plugin.initialize(session, "Fix bug Y");
+        plugin.sendMessage("PROJ-10-xyz", "What is the status?");
+
+        verify(httpClient, times(2)).send(any(HttpRequest.class), any());
+    }
+
+    @Test
+    void sendMessage_throwsWhenSessionNotInitialized() {
+        assertThrows(IllegalStateException.class,
+            () -> plugin.sendMessage("nonexistent-session", "hello"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void sendMessage_throwsOnNonSuccessHttpStatus() throws Exception {
+        HttpResponse<String> okResponse = (HttpResponse<String>) mock(HttpResponse.class);
+        when(okResponse.statusCode()).thenReturn(200);
+        when(okResponse.body()).thenReturn(buildAnthropicResponse("Ready."));
+
+        HttpResponse<String> errResponse = (HttpResponse<String>) mock(HttpResponse.class);
+        when(errResponse.statusCode()).thenReturn(429);
+        when(errResponse.body()).thenReturn("{\"error\":\"rate_limited\"}");
+
+        doReturn(okResponse).doReturn(errResponse).when(httpClient).send(any(HttpRequest.class), any());
+
+        AgentSession session = new AgentSession("s1");
+        plugin.initialize(session, "context");
+
+        assertThrows(RuntimeException.class, () -> plugin.sendMessage("s1", "retry?"));
+    }
+
+    @Test
+    void initialize_throwsWhenApiKeyMissing() {
+        ClaudeAgentPlugin noKey = new ClaudeAgentPlugin(null, ClaudeAgentPlugin.DEFAULT_MODEL, httpClient);
+        assertThrows(IllegalStateException.class,
+            () -> noKey.initialize(new AgentSession("s"), "ctx"));
+    }
+
+    @Test
+    void extractTextFromResponse_parsesFirstTextBlock() {
+        String response = buildAnthropicResponse("Hello world");
+        String text = plugin.extractTextFromResponse(response);
+        assertEquals("Hello world", text);
+    }
+
+    @Test
+    void extractTextFromResponse_returnsEmptyWhenNoTextBlock() {
+        assertEquals("", plugin.extractTextFromResponse("{}"));
+    }
+
+    // -------------------------------------------------------------------------
+    // helpers
+    // -------------------------------------------------------------------------
+
+    private String buildAnthropicResponse(String text) {
+        return "{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\","
+            + "\"content\":[{\"type\":\"text\",\"text\":\"" + text + "\"}],"
+            + "\"model\":\"" + ClaudeAgentPlugin.DEFAULT_MODEL + "\","
+            + "\"stop_reason\":\"end_turn\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}";
+    }
+}

--- a/src/test/java/com/visa/nucleus/plugins/agent/OpenAIAgentPluginTest.java
+++ b/src/test/java/com/visa/nucleus/plugins/agent/OpenAIAgentPluginTest.java
@@ -1,0 +1,116 @@
+package com.visa.nucleus.plugins.agent;
+
+import com.visa.nucleus.core.AgentSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class OpenAIAgentPluginTest {
+
+    private HttpClient httpClient;
+    @SuppressWarnings("unchecked")
+    private HttpResponse<String> httpResponse = (HttpResponse<String>) mock(HttpResponse.class);
+    private OpenAIAgentPlugin plugin;
+
+    @BeforeEach
+    void setUp() {
+        httpClient = mock(HttpClient.class);
+        plugin = new OpenAIAgentPlugin("test-api-key", OpenAIAgentPlugin.DEFAULT_MODEL, httpClient);
+    }
+
+    @Test
+    void getAgentType_returnsOpenai() {
+        assertEquals("openai", plugin.getAgentType());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void initialize_sendsFirstMessage() throws Exception {
+        when(httpResponse.statusCode()).thenReturn(200);
+        when(httpResponse.body()).thenReturn(buildOpenAIResponse("Ready to start."));
+        doReturn(httpResponse).when(httpClient).send(any(HttpRequest.class), any());
+
+        AgentSession session = new AgentSession("PROJ-42-abc");
+        plugin.initialize(session, "Implement feature X");
+
+        verify(httpClient, times(1)).send(any(HttpRequest.class), any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void sendMessage_appendsToConversationHistory() throws Exception {
+        when(httpResponse.statusCode()).thenReturn(200);
+        when(httpResponse.body())
+                .thenReturn(buildOpenAIResponse("Ready."))
+                .thenReturn(buildOpenAIResponse("Done."));
+        doReturn(httpResponse).when(httpClient).send(any(HttpRequest.class), any());
+
+        AgentSession session = new AgentSession("PROJ-10-xyz");
+        plugin.initialize(session, "Fix bug Y");
+        plugin.sendMessage("PROJ-10-xyz", "What is the status?");
+
+        verify(httpClient, times(2)).send(any(HttpRequest.class), any());
+    }
+
+    @Test
+    void sendMessage_throwsWhenSessionNotInitialized() {
+        assertThrows(IllegalStateException.class,
+            () -> plugin.sendMessage("nonexistent-session", "hello"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void sendMessage_throwsOnNonSuccessHttpStatus() throws Exception {
+        HttpResponse<String> okResponse = (HttpResponse<String>) mock(HttpResponse.class);
+        when(okResponse.statusCode()).thenReturn(200);
+        when(okResponse.body()).thenReturn(buildOpenAIResponse("Ready."));
+
+        HttpResponse<String> errResponse = (HttpResponse<String>) mock(HttpResponse.class);
+        when(errResponse.statusCode()).thenReturn(401);
+        when(errResponse.body()).thenReturn("{\"error\":{\"message\":\"invalid key\"}}");
+
+        doReturn(okResponse).doReturn(errResponse).when(httpClient).send(any(HttpRequest.class), any());
+
+        AgentSession session = new AgentSession("s1");
+        plugin.initialize(session, "context");
+
+        assertThrows(RuntimeException.class, () -> plugin.sendMessage("s1", "retry?"));
+    }
+
+    @Test
+    void initialize_throwsWhenApiKeyMissing() {
+        OpenAIAgentPlugin noKey = new OpenAIAgentPlugin(null, OpenAIAgentPlugin.DEFAULT_MODEL, httpClient);
+        assertThrows(IllegalStateException.class,
+            () -> noKey.initialize(new AgentSession("s"), "ctx"));
+    }
+
+    @Test
+    void extractContentFromResponse_parsesContent() {
+        String response = buildOpenAIResponse("Hello world");
+        String text = plugin.extractContentFromResponse(response);
+        assertEquals("Hello world", text);
+    }
+
+    @Test
+    void extractContentFromResponse_returnsEmptyWhenNoContent() {
+        assertEquals("", plugin.extractContentFromResponse("{}"));
+    }
+
+    // -------------------------------------------------------------------------
+    // helpers
+    // -------------------------------------------------------------------------
+
+    private String buildOpenAIResponse(String content) {
+        return "{\"id\":\"chatcmpl-1\",\"object\":\"chat.completion\","
+            + "\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\","
+            + "\"content\":\"" + content + "\"},\"finish_reason\":\"stop\"}],"
+            + "\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}";
+    }
+}


### PR DESCRIPTION
## Summary

- **`ClaudeAgentPlugin`**: implements `AgentPlugin` using the Anthropic API (`claude-sonnet-4-6`). Reads `ANTHROPIC_API_KEY` from environment. Stores system prompts and full conversation history per session in `ConcurrentHashMap`.
- **`OpenAIAgentPlugin`**: same interface, calls OpenAI Chat Completions API (`gpt-4o`). Reads `OPENAI_API_KEY` from environment.
- **`AgentPluginFactory`**: returns the correct plugin for `"claude"` or `"openai"` agent types (case-insensitive).

Both plugins:
- Build a system prompt from `issueContext` and `sessionId` on `initialize()`
- Send an opening message to kick off the agent
- Append user/assistant turns to conversation history on each `sendMessage()` call
- Throw `IllegalStateException` for missing API keys or uninitialized sessions
- Use Java's built-in `HttpClient` (no additional dependencies)

## Test plan

- [x] `ClaudeAgentPluginTest` — 7 tests: agent type, initialize, message history, uninitialized session, HTTP error, missing key, response parsing
- [x] `OpenAIAgentPluginTest` — 7 tests: same coverage for OpenAI plugin
- [x] `AgentPluginFactoryTest` — 5 tests: correct plugin returned, case-insensitive, null/unknown type throws

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)