### PR TITLE
feat: add agent-orchestrator.yaml config file support

### DIFF
--- a/agent-orchestrator.yaml
+++ b/agent-orchestrator.yaml
@@ -1,0 +1,32 @@
+# Nucleus AI — Agent Orchestrator Configuration
+# This file is the single source of truth for projects, plugins, and reaction rules.
+# Place it in the working directory or set NUCLEUS_CONFIG env var to its path.
+
+port: 3000
+
+defaults:
+  runtime: docker          # docker | tmux
+  agent: claude            # claude | openai
+  workspace: worktree      # worktree | clone
+  notifiers: [teams]       # teams | slack | desktop | webhook
+
+projects:
+  my-app:
+    repo: owner/my-app
+    path: ~/my-app
+    defaultBranch: main
+    jiraProjectKey: MYAPP
+    sessionPrefix: app
+
+reactions:
+  ci-failed:
+    auto: true
+    action: send-to-agent
+    retries: 3
+  changes-requested:
+    auto: true
+    action: send-to-agent
+    escalateAfter: 30m
+  approved-and-green:
+    auto: false
+    action: notify

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,10 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+        </dependency>
 
         <!-- Docker Java client -->
         <dependency>

--- a/src/main/java/com/visa/nucleus/config/ConfigLoader.java
+++ b/src/main/java/com/visa/nucleus/config/ConfigLoader.java
@@ -1,0 +1,65 @@
+package com.visa.nucleus.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Loads {@code agent-orchestrator.yaml} and exposes it as a {@link NucleusProperties} bean.
+ *
+ * <p>Resolution order:
+ * <ol>
+ *   <li>File path in the {@code NUCLEUS_CONFIG} environment variable.</li>
+ *   <li>{@code ./agent-orchestrator.yaml} in the current working directory.</li>
+ *   <li>Default {@link NucleusProperties} values if neither file is present.</li>
+ * </ol>
+ */
+@Configuration
+@EnableConfigurationProperties(NucleusProperties.class)
+public class ConfigLoader {
+
+    private static final Logger log = LoggerFactory.getLogger(ConfigLoader.class);
+    private static final String DEFAULT_CONFIG_FILENAME = "agent-orchestrator.yaml";
+
+    /**
+     * Returns a {@link NucleusProperties} bean populated from the external YAML config file.
+     * Falls back to default values when the file is absent.
+     */
+    @Bean
+    @Primary
+    public NucleusProperties nucleusProperties() {
+        File configFile = resolveConfigFile();
+
+        if (configFile != null && configFile.exists()) {
+            try {
+                ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+                mapper.findAndRegisterModules();
+                NucleusProperties props = mapper.readValue(configFile, NucleusProperties.class);
+                log.info("Loaded Nucleus config from: {}", configFile.getAbsolutePath());
+                return props;
+            } catch (IOException e) {
+                log.warn("Failed to parse '{}', falling back to defaults: {}", configFile.getAbsolutePath(), e.getMessage());
+            }
+        } else {
+            log.info("No agent-orchestrator.yaml found; using built-in defaults.");
+        }
+
+        return new NucleusProperties();
+    }
+
+    private File resolveConfigFile() {
+        String envPath = System.getenv("NUCLEUS_CONFIG");
+        if (envPath != null && !envPath.isBlank()) {
+            return new File(envPath);
+        }
+        return new File(DEFAULT_CONFIG_FILENAME);
+    }
+}

--- a/src/main/java/com/visa/nucleus/config/NucleusProperties.java
+++ b/src/main/java/com/visa/nucleus/config/NucleusProperties.java
@@ -1,0 +1,107 @@
+package com.visa.nucleus.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Top-level configuration properties for Nucleus AI, populated from
+ * {@code agent-orchestrator.yaml} (or {@code application.yml} as fallback).
+ *
+ * <p>The external config file location is resolved in this order:
+ * <ol>
+ *   <li>Path provided by the {@code NUCLEUS_CONFIG} environment variable.</li>
+ *   <li>{@code ./agent-orchestrator.yaml} in the working directory.</li>
+ *   <li>Spring {@code application.yml} values under the {@code nucleus} prefix.</li>
+ * </ol>
+ */
+@ConfigurationProperties(prefix = "nucleus")
+public class NucleusProperties {
+
+    private int port = 3000;
+    private Defaults defaults = new Defaults();
+    private Map<String, ProjectConfig> projects = new HashMap<>();
+    private Map<String, ReactionRule> reactions = new HashMap<>();
+
+    // -------------------------------------------------------------------------
+    // Nested: Defaults
+    // -------------------------------------------------------------------------
+
+    public static class Defaults {
+        private String runtime = "docker";
+        private String agent = "claude";
+        private String workspace = "worktree";
+        private List<String> notifiers = new ArrayList<>(List.of("teams"));
+
+        public String getRuntime() {
+            return runtime;
+        }
+
+        public void setRuntime(String runtime) {
+            this.runtime = runtime;
+        }
+
+        public String getAgent() {
+            return agent;
+        }
+
+        public void setAgent(String agent) {
+            this.agent = agent;
+        }
+
+        public String getWorkspace() {
+            return workspace;
+        }
+
+        public void setWorkspace(String workspace) {
+            this.workspace = workspace;
+        }
+
+        public List<String> getNotifiers() {
+            return notifiers;
+        }
+
+        public void setNotifiers(List<String> notifiers) {
+            this.notifiers = notifiers;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Accessors
+    // -------------------------------------------------------------------------
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public Defaults getDefaults() {
+        return defaults;
+    }
+
+    public void setDefaults(Defaults defaults) {
+        this.defaults = defaults;
+    }
+
+    public Map<String, ProjectConfig> getProjects() {
+        return projects;
+    }
+
+    public void setProjects(Map<String, ProjectConfig> projects) {
+        this.projects = projects;
+    }
+
+    public Map<String, ReactionRule> getReactions() {
+        return reactions;
+    }
+
+    public void setReactions(Map<String, ReactionRule> reactions) {
+        this.reactions = reactions;
+    }
+}

--- a/src/main/java/com/visa/nucleus/config/ProjectConfig.java
+++ b/src/main/java/com/visa/nucleus/config/ProjectConfig.java
@@ -1,0 +1,53 @@
+package com.visa.nucleus.config;
+
+/**
+ * Per-project configuration loaded from agent-orchestrator.yaml.
+ */
+public class ProjectConfig {
+
+    private String repo;
+    private String path;
+    private String defaultBranch = "main";
+    private String jiraProjectKey;
+    private String sessionPrefix;
+
+    public String getRepo() {
+        return repo;
+    }
+
+    public void setRepo(String repo) {
+        this.repo = repo;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public String getDefaultBranch() {
+        return defaultBranch;
+    }
+
+    public void setDefaultBranch(String defaultBranch) {
+        this.defaultBranch = defaultBranch;
+    }
+
+    public String getJiraProjectKey() {
+        return jiraProjectKey;
+    }
+
+    public void setJiraProjectKey(String jiraProjectKey) {
+        this.jiraProjectKey = jiraProjectKey;
+    }
+
+    public String getSessionPrefix() {
+        return sessionPrefix;
+    }
+
+    public void setSessionPrefix(String sessionPrefix) {
+        this.sessionPrefix = sessionPrefix;
+    }
+}

--- a/src/main/java/com/visa/nucleus/config/ReactionRule.java
+++ b/src/main/java/com/visa/nucleus/config/ReactionRule.java
@@ -1,0 +1,46 @@
+package com.visa.nucleus.config;
+
+/**
+ * Configuration for a single reaction rule in agent-orchestrator.yaml.
+ * Example rules: ci-failed, changes-requested, approved-and-green.
+ */
+public class ReactionRule {
+
+    private boolean auto = false;
+    private String action;
+    private int retries = 0;
+    /** Escalation timeout expressed as a string (e.g. "30m", "1h"). */
+    private String escalateAfter;
+
+    public boolean isAuto() {
+        return auto;
+    }
+
+    public void setAuto(boolean auto) {
+        this.auto = auto;
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public void setAction(String action) {
+        this.action = action;
+    }
+
+    public int getRetries() {
+        return retries;
+    }
+
+    public void setRetries(int retries) {
+        this.retries = retries;
+    }
+
+    public String getEscalateAfter() {
+        return escalateAfter;
+    }
+
+    public void setEscalateAfter(String escalateAfter) {
+        this.escalateAfter = escalateAfter;
+    }
+}

--- a/src/main/java/com/visa/nucleus/core/service/OrchestratorService.java
+++ b/src/main/java/com/visa/nucleus/core/service/OrchestratorService.java
@@ -1,5 +1,8 @@
 package com.visa.nucleus.core.service;
 
+import com.visa.nucleus.config.NucleusProperties;
+import com.visa.nucleus.config.ProjectConfig;
+import com.visa.nucleus.config.ReactionRule;
 import com.visa.nucleus.core.AgentSession;
 import com.visa.nucleus.core.plugin.AgentPlugin;
 import com.visa.nucleus.core.plugin.NotificationLevel;
@@ -12,10 +15,11 @@ import com.visa.nucleus.core.plugin.WorkspacePlugin;
  * OrchestratorService is the main brain that coordinates all six plugins:
  * TrackerPlugin, WorkspacePlugin, RuntimePlugin, AgentPlugin, NotifierPlugin,
  * and ScmPlugin. It manages the full lifecycle of an agent session.
+ *
+ * <p>Plugin selection and reaction behaviour is driven by {@link NucleusProperties}
+ * loaded from {@code agent-orchestrator.yaml}.
  */
 public class OrchestratorService {
-
-    private static final int MAX_CI_RETRIES = 3;
 
     private final SessionManager sessionManager;
     private final TrackerPlugin trackerPlugin;
@@ -23,6 +27,7 @@ public class OrchestratorService {
     private final RuntimePlugin runtimePlugin;
     private final AgentPlugin agentPlugin;
     private final NotifierPlugin notifierPlugin;
+    private final NucleusProperties nucleusProperties;
     private final String repoPath;
 
     public OrchestratorService(
@@ -32,6 +37,7 @@ public class OrchestratorService {
             RuntimePlugin runtimePlugin,
             AgentPlugin agentPlugin,
             NotifierPlugin notifierPlugin,
+            NucleusProperties nucleusProperties,
             String repoPath) {
         this.sessionManager = sessionManager;
         this.trackerPlugin = trackerPlugin;
@@ -39,7 +45,28 @@ public class OrchestratorService {
         this.runtimePlugin = runtimePlugin;
         this.agentPlugin = agentPlugin;
         this.notifierPlugin = notifierPlugin;
+        this.nucleusProperties = nucleusProperties;
         this.repoPath = repoPath;
+    }
+
+    /**
+     * Returns the effective {@link ProjectConfig} for the given project name,
+     * or {@code null} if the project is not explicitly configured.
+     */
+    public ProjectConfig getProjectConfig(String projectName) {
+        return nucleusProperties.getProjects().get(projectName);
+    }
+
+    /**
+     * Returns the effective max CI retries for a given project, falling back to
+     * the reaction rule configured under {@code ci-failed}, then to 3.
+     */
+    private int maxCiRetries(String projectName) {
+        ReactionRule rule = nucleusProperties.getReactions().get("ci-failed");
+        if (rule != null && rule.getRetries() > 0) {
+            return rule.getRetries();
+        }
+        return 3;
     }
 
     /**
@@ -119,7 +146,7 @@ public class OrchestratorService {
      *   <li>Fetches the session from DB.</li>
      *   <li>Forwards the CI failure logs to the agent.</li>
      *   <li>Increments the ciRetryCount.</li>
-     *   <li>If retryCount &gt; {@value #MAX_CI_RETRIES}, notifies via notifierPlugin with
+     *   <li>If retryCount exceeds the configured {@code reactions.ci-failed.retries} limit, notifies via notifierPlugin with
      *       NEEDS_ATTENTION level.</li>
      *   <li>Saves the updated session.</li>
      * </ol>
@@ -134,8 +161,8 @@ public class OrchestratorService {
         // 3. Increment retry count
         session.incrementCiRetryCount();
 
-        // 4. Escalate if too many retries
-        if (session.getCiRetryCount() > MAX_CI_RETRIES) {
+        // 4. Escalate if too many retries (limit comes from reactions.ci-failed.retries)
+        if (session.getCiRetryCount() > maxCiRetries(session.getProjectName())) {
             notifierPlugin.notify(sessionId,
                     "Session " + sessionId + " has failed CI " + session.getCiRetryCount() + " times and needs attention.",
                     NotificationLevel.NEEDS_ATTENTION);


### PR DESCRIPTION
## Summary

- Adds `ConfigLoader` that reads `agent-orchestrator.yaml` from the working directory (or path in `NUCLEUS_CONFIG` env var), with fallback to defaults
- Introduces `NucleusProperties` (`@ConfigurationProperties`) with nested `Defaults`, `ProjectConfig`, and `ReactionRule` models
- Adds `jackson-dataformat-yaml` dependency for YAML parsing
- Wires `NucleusProperties` into `OrchestratorService` so CI retry limits and project configs come from the config file instead of hardcoded values
- Ships a sample `agent-orchestrator.yaml` in the repo root documenting all supported keys

Closes #29

## Test plan

- [ ] Run with `agent-orchestrator.yaml` present — verify properties are loaded and logged at startup
- [ ] Run without the file — verify startup succeeds with defaults (port 3000, docker runtime, claude agent)
- [ ] Set `NUCLEUS_CONFIG=/path/to/custom.yaml` — verify the custom path is loaded
- [ ] Confirm CI retry threshold respects `reactions.ci-failed.retries` from config

🤖 Generated with [Claude Code](https://claude.com/claude-code)