### PR TITLE
feat: implement TmuxRuntimePlugin as default agent runtime

### DIFF
--- a/agent-orchestrator.yaml
+++ b/agent-orchestrator.yaml
@@ -5,7 +5,7 @@
 port: 3000
 
 defaults:
-  runtime: docker          # docker | tmux
+  runtime: tmux            # docker | tmux
   agent: claude            # claude | openai
   workspace: worktree      # worktree | clone
   notifiers: [teams]       # teams | slack | desktop | webhook

--- a/src/main/java/com/visa/nucleus/NucleusConfig.java
+++ b/src/main/java/com/visa/nucleus/NucleusConfig.java
@@ -1,0 +1,21 @@
+package com.visa.nucleus;
+
+import com.visa.nucleus.core.plugin.RuntimePlugin;
+import com.visa.nucleus.plugins.runtime.DockerRuntimePlugin;
+import com.visa.nucleus.plugins.runtime.TmuxRuntimePlugin;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class NucleusConfig {
+
+    @Bean
+    public RuntimePlugin runtimePlugin(NucleusProperties props) {
+        return switch (props.getDefaults().getRuntime()) {
+            case "tmux" -> new TmuxRuntimePlugin();
+            case "docker" -> new DockerRuntimePlugin();
+            default -> throw new IllegalArgumentException(
+                    "Unknown runtime: " + props.getDefaults().getRuntime());
+        };
+    }
+}

--- a/src/main/java/com/visa/nucleus/NucleusProperties.java
+++ b/src/main/java/com/visa/nucleus/NucleusProperties.java
@@ -1,0 +1,33 @@
+package com.visa.nucleus;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "nucleus")
+public class NucleusProperties {
+
+    private Defaults defaults = new Defaults();
+
+    public Defaults getDefaults() {
+        return defaults;
+    }
+
+    public void setDefaults(Defaults defaults) {
+        this.defaults = defaults;
+    }
+
+    public static class Defaults {
+
+        /** Runtime plugin to use: "tmux" (default) or "docker". */
+        private String runtime = "tmux";
+
+        public String getRuntime() {
+            return runtime;
+        }
+
+        public void setRuntime(String runtime) {
+            this.runtime = runtime;
+        }
+    }
+}

--- a/src/main/java/com/visa/nucleus/plugins/runtime/TmuxRuntimePlugin.java
+++ b/src/main/java/com/visa/nucleus/plugins/runtime/TmuxRuntimePlugin.java
@@ -1,0 +1,132 @@
+package com.visa.nucleus.plugins.runtime;
+
+import com.visa.nucleus.core.AgentSession;
+import com.visa.nucleus.core.plugin.RuntimePlugin;
+import com.visa.nucleus.plugins.workspace.ProcessRunner;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * RuntimePlugin implementation that manages agent sessions via tmux.
+ *
+ * Each agent session runs in a tmux session named nucleus-{sessionId}
+ * with the session's worktree as the working directory.
+ */
+public class TmuxRuntimePlugin implements RuntimePlugin {
+
+    static final String SESSION_PREFIX = "nucleus-";
+    static final String INSTRUCTIONS_FILE = ".nucleus-instructions.txt";
+
+    private final ProcessRunner processRunner;
+    // Maps sessionId -> worktreePath so sendInstruction can append to the file
+    private final ConcurrentHashMap<String, String> sessionWorktrees = new ConcurrentHashMap<>();
+
+    /** Default constructor. */
+    public TmuxRuntimePlugin() {
+        this(new ProcessRunner());
+    }
+
+    /** Constructor for dependency injection (testing). */
+    public TmuxRuntimePlugin(ProcessRunner processRunner) {
+        this.processRunner = processRunner;
+    }
+
+    /**
+     * Creates a new detached tmux session for the agent, sets environment variables,
+     * and stores the tmux session name back on the AgentSession.
+     */
+    @Override
+    public void start(AgentSession session) throws Exception {
+        String tmuxSession = SESSION_PREFIX + session.getSessionId();
+        String worktreePath = session.getWorktreePath();
+        String anthropicKey = System.getenv("ANTHROPIC_API_KEY");
+
+        processRunner.run(
+                List.of("tmux", "new-session", "-d", "-s", tmuxSession, "-c", worktreePath),
+                worktreePath
+        );
+
+        processRunner.run(
+                List.of("tmux", "setenv", "-t", tmuxSession,
+                        "ANTHROPIC_API_KEY", anthropicKey != null ? anthropicKey : ""),
+                worktreePath
+        );
+        processRunner.run(
+                List.of("tmux", "setenv", "-t", tmuxSession, "SESSION_ID", session.getSessionId()),
+                worktreePath
+        );
+
+        session.setContainerId(tmuxSession);
+        sessionWorktrees.put(session.getSessionId(), worktreePath);
+    }
+
+    /**
+     * Kills the tmux session for the given sessionId.
+     * Silently ignores if the session does not exist.
+     */
+    @Override
+    public void stop(String sessionId) throws Exception {
+        String tmuxSession = SESSION_PREFIX + sessionId;
+        try {
+            processRunner.run(List.of("tmux", "kill-session", "-t", tmuxSession), "/tmp");
+        } catch (Exception ignored) {
+            // silently ignore — session may not exist
+        }
+        sessionWorktrees.remove(sessionId);
+    }
+
+    /**
+     * Appends the instruction to the agent's instruction file in the worktree,
+     * then sends the instruction directly to the tmux session via send-keys.
+     */
+    @Override
+    public void sendInstruction(String sessionId, String instruction) throws Exception {
+        String tmuxSession = SESSION_PREFIX + sessionId;
+        String worktreePath = sessionWorktrees.get(sessionId);
+
+        if (worktreePath != null) {
+            String escaped = instruction.replace("'", "'\\''");
+            processRunner.run(
+                    List.of("sh", "-c",
+                            "echo '" + escaped + "' >> " + worktreePath + "/" + INSTRUCTIONS_FILE),
+                    worktreePath
+            );
+        }
+
+        processRunner.run(
+                List.of("tmux", "send-keys", "-t", tmuxSession, instruction, "Enter"),
+                "/tmp"
+        );
+    }
+
+    /**
+     * Captures the last 200 lines of the tmux pane and returns them as a string.
+     */
+    @Override
+    public String getLogs(String sessionId) throws Exception {
+        String tmuxSession = SESSION_PREFIX + sessionId;
+        try {
+            return processRunner.run(
+                    List.of("tmux", "capture-pane", "-t", tmuxSession, "-p", "-S", "-200"),
+                    "/tmp"
+            );
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+    /**
+     * Returns true if a tmux session with the given sessionId is currently running.
+     */
+    @Override
+    public boolean isRunning(String sessionId) {
+        String tmuxSession = SESSION_PREFIX + sessionId;
+        try {
+            processRunner.run(List.of("tmux", "has-session", "-t", tmuxSession), "/tmp");
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 server:
   port: 8080
 
+nucleus:
+  defaults:
+    runtime: tmux   # or docker
+
 spring:
   datasource:
     url: jdbc:postgresql://${DB_HOST:localhost}:5432/${DB_NAME:nucleus_ai}

--- a/src/test/java/com/visa/nucleus/plugins/runtime/TmuxRuntimePluginTest.java
+++ b/src/test/java/com/visa/nucleus/plugins/runtime/TmuxRuntimePluginTest.java
@@ -1,0 +1,208 @@
+package com.visa.nucleus.plugins.runtime;
+
+import com.visa.nucleus.core.AgentSession;
+import com.visa.nucleus.plugins.workspace.ProcessRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TmuxRuntimePluginTest {
+
+    @Mock
+    private ProcessRunner processRunner;
+
+    private TmuxRuntimePlugin plugin;
+
+    @BeforeEach
+    void setUp() {
+        plugin = new TmuxRuntimePlugin(processRunner);
+    }
+
+    // -----------------------------------------------------------------------
+    // start()
+    // -----------------------------------------------------------------------
+
+    @Test
+    void start_createsNewTmuxSessionInWorktreeDirectory() throws Exception {
+        AgentSession session = new AgentSession("sess-1");
+        session.setWorktreePath("/tmp/worktrees/sess-1");
+
+        plugin.start(session);
+
+        verify(processRunner).run(
+                eq(List.of("tmux", "new-session", "-d", "-s", "nucleus-sess-1", "-c", "/tmp/worktrees/sess-1")),
+                eq("/tmp/worktrees/sess-1")
+        );
+    }
+
+    @Test
+    void start_setsSessionIdEnvVar() throws Exception {
+        AgentSession session = new AgentSession("sess-1");
+        session.setWorktreePath("/tmp/worktrees/sess-1");
+
+        plugin.start(session);
+
+        verify(processRunner).run(
+                eq(List.of("tmux", "setenv", "-t", "nucleus-sess-1", "SESSION_ID", "sess-1")),
+                eq("/tmp/worktrees/sess-1")
+        );
+    }
+
+    @Test
+    void start_storesTmuxSessionNameAsContainerId() throws Exception {
+        AgentSession session = new AgentSession("sess-2");
+        session.setWorktreePath("/tmp/worktrees/sess-2");
+
+        plugin.start(session);
+
+        assertEquals("nucleus-sess-2", session.getContainerId());
+    }
+
+    // -----------------------------------------------------------------------
+    // stop()
+    // -----------------------------------------------------------------------
+
+    @Test
+    void stop_killsTmuxSession() throws Exception {
+        plugin.stop("sess-1");
+
+        verify(processRunner).run(
+                eq(List.of("tmux", "kill-session", "-t", "nucleus-sess-1")),
+                eq("/tmp")
+        );
+    }
+
+    @Test
+    void stop_silentlyIgnoresWhenSessionNotFound() throws Exception {
+        when(processRunner.run(any(), anyString()))
+                .thenThrow(new RuntimeException("no server running on /tmp/tmux-..."));
+
+        assertDoesNotThrow(() -> plugin.stop("nonexistent-sess"));
+    }
+
+    // -----------------------------------------------------------------------
+    // sendInstruction()
+    // -----------------------------------------------------------------------
+
+    @Test
+    void sendInstruction_sendsKeysToTmuxSession() throws Exception {
+        plugin.sendInstruction("sess-1", "run the tests");
+
+        verify(processRunner).run(
+                eq(List.of("tmux", "send-keys", "-t", "nucleus-sess-1", "run the tests", "Enter")),
+                eq("/tmp")
+        );
+    }
+
+    @Test
+    void sendInstruction_appendsToInstructionFileWhenWorktreeKnown() throws Exception {
+        AgentSession session = new AgentSession("sess-1");
+        session.setWorktreePath("/tmp/worktrees/sess-1");
+        plugin.start(session);
+        reset(processRunner);
+
+        plugin.sendInstruction("sess-1", "run the tests");
+
+        verify(processRunner).run(
+                eq(List.of("sh", "-c",
+                        "echo 'run the tests' >> /tmp/worktrees/sess-1/.nucleus-instructions.txt")),
+                eq("/tmp/worktrees/sess-1")
+        );
+    }
+
+    @Test
+    void sendInstruction_escapesSingleQuotesInInstruction() throws Exception {
+        AgentSession session = new AgentSession("sess-1");
+        session.setWorktreePath("/tmp/worktrees/sess-1");
+        plugin.start(session);
+        reset(processRunner);
+
+        plugin.sendInstruction("sess-1", "it's a test");
+
+        verify(processRunner).run(
+                eq(List.of("sh", "-c",
+                        "echo 'it'\\''s a test' >> /tmp/worktrees/sess-1/.nucleus-instructions.txt")),
+                eq("/tmp/worktrees/sess-1")
+        );
+    }
+
+    @Test
+    void sendInstruction_skipsFileAppendWhenWorktreeUnknown() throws Exception {
+        // sendInstruction called without prior start — worktree unknown
+        plugin.sendInstruction("sess-orphan", "hello");
+
+        // only the send-keys command should be issued
+        verify(processRunner, times(1)).run(any(), anyString());
+        verify(processRunner).run(
+                eq(List.of("tmux", "send-keys", "-t", "nucleus-sess-orphan", "hello", "Enter")),
+                eq("/tmp")
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // getLogs()
+    // -----------------------------------------------------------------------
+
+    @Test
+    void getLogs_capturesPaneOutputWithScrollback() throws Exception {
+        when(processRunner.run(any(), anyString())).thenReturn("pane output here");
+
+        String logs = plugin.getLogs("sess-1");
+
+        verify(processRunner).run(
+                eq(List.of("tmux", "capture-pane", "-t", "nucleus-sess-1", "-p", "-S", "-200")),
+                eq("/tmp")
+        );
+        assertEquals("pane output here", logs);
+    }
+
+    @Test
+    void getLogs_returnsEmptyStringWhenSessionNotFound() throws Exception {
+        when(processRunner.run(any(), anyString()))
+                .thenThrow(new RuntimeException("can't find session: nucleus-unknown"));
+
+        assertEquals("", plugin.getLogs("unknown-sess"));
+    }
+
+    // -----------------------------------------------------------------------
+    // isRunning()
+    // -----------------------------------------------------------------------
+
+    @Test
+    void isRunning_returnsTrueWhenSessionExists() throws Exception {
+        when(processRunner.run(any(), anyString())).thenReturn("");
+
+        assertTrue(plugin.isRunning("sess-1"));
+        verify(processRunner).run(
+                eq(List.of("tmux", "has-session", "-t", "nucleus-sess-1")),
+                eq("/tmp")
+        );
+    }
+
+    @Test
+    void isRunning_returnsFalseWhenSessionNotFound() throws Exception {
+        when(processRunner.run(any(), anyString()))
+                .thenThrow(new RuntimeException("Command failed with exit code 1"));
+
+        assertFalse(plugin.isRunning("missing-sess"));
+    }
+
+    @Test
+    void isRunning_returnsFalseOnUnexpectedException() throws Exception {
+        when(processRunner.run(any(), anyString()))
+                .thenThrow(new RuntimeException("unexpected error"));
+
+        assertFalse(plugin.isRunning("sess-1"));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `TmuxRuntimePlugin` implementing `RuntimePlugin` using tmux sessions named `nucleus-{sessionId}`; reuses existing `ProcessRunner` for all tmux commands
- Add `NucleusProperties` (`@ConfigurationProperties`) and `NucleusConfig` (`@Configuration`) to select the runtime plugin (`tmux` or `docker`) from config
- Add `agent-orchestrator.yaml` with `defaults.runtime: tmux`
- Update `application.yml` with `nucleus.defaults.runtime: tmux`
- Add 14 unit tests covering all `TmuxRuntimePlugin` methods (start, stop, sendInstruction, getLogs, isRunning)

## Test plan

- [x] `TmuxRuntimePluginTest` — 14 tests, all pass (mocked ProcessRunner)
- [x] Full test suite — 111 tests, 0 failures

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)