### PR TITLE
feat: implement session restore for FAILED sessions

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -14,6 +14,7 @@ const COLUMNS: { status: SessionStatus; label: string }[] = [
   { status: 'PR_OPEN', label: 'PR OPEN' },
   { status: 'IN_REVIEW', label: 'IN REVIEW' },
   { status: 'MERGED', label: 'MERGED' },
+  { status: 'FAILED', label: 'FAILED' },
 ];
 
 const COLUMN_ACCENT: Record<SessionStatus, string> = {
@@ -22,6 +23,7 @@ const COLUMN_ACCENT: Record<SessionStatus, string> = {
   PR_OPEN: 'border-purple-500',
   IN_REVIEW: 'border-orange-500',
   MERGED: 'border-green-500',
+  FAILED: 'border-red-500',
 };
 
 export default function Dashboard() {

--- a/frontend/components/SessionCard.tsx
+++ b/frontend/components/SessionCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { ExternalLink, MessageSquare, FileText } from 'lucide-react';
+import { ExternalLink, MessageSquare, FileText, RefreshCw } from 'lucide-react';
 import { Session } from '../types/session';
 
 const STATUS_COLORS: Record<string, string> = {
@@ -10,6 +10,7 @@ const STATUS_COLORS: Record<string, string> = {
   PR_OPEN: 'bg-purple-400',
   IN_REVIEW: 'bg-orange-400',
   MERGED: 'bg-green-400',
+  FAILED: 'bg-red-400',
 };
 
 const AGENT_BADGE_COLORS: Record<string, string> = {
@@ -45,7 +46,19 @@ interface Props {
 export default function SessionCard({ session, onViewLogs }: Props) {
   const [showMessageInput, setShowMessageInput] = useState(false);
   const [message, setMessage] = useState('');
+  const [restoring, setRestoring] = useState(false);
   const elapsed = useElapsed(session.spawnedAt);
+
+  const handleRestore = async () => {
+    setRestoring(true);
+    try {
+      await fetch(`/api/sessions/${session.id}/restore`, { method: 'POST' });
+    } catch (err) {
+      console.error('Failed to restore session', err);
+    } finally {
+      setRestoring(false);
+    }
+  };
 
   const handleSendMessage = async () => {
     if (!message.trim()) return;
@@ -116,14 +129,25 @@ export default function SessionCard({ session, onViewLogs }: Props) {
         </div>
       )}
 
-      <div className="flex gap-2 mt-1">
-        <button
-          onClick={() => setShowMessageInput((v) => !v)}
-          className="flex items-center gap-1 text-xs text-gray-400 hover:text-white transition-colors"
-        >
-          <MessageSquare size={12} />
-          Send Message
-        </button>
+      <div className="flex gap-2 mt-1 flex-wrap">
+        {session.status === 'FAILED' ? (
+          <button
+            onClick={handleRestore}
+            disabled={restoring}
+            className="flex items-center gap-1 text-xs text-red-400 hover:text-red-300 transition-colors disabled:opacity-50"
+          >
+            <RefreshCw size={12} className={restoring ? 'animate-spin' : ''} />
+            {restoring ? 'Restoring…' : 'Restore'}
+          </button>
+        ) : (
+          <button
+            onClick={() => setShowMessageInput((v) => !v)}
+            className="flex items-center gap-1 text-xs text-gray-400 hover:text-white transition-colors"
+          >
+            <MessageSquare size={12} />
+            Send Message
+          </button>
+        )}
         <button
           onClick={() => onViewLogs(session)}
           className="flex items-center gap-1 text-xs text-gray-400 hover:text-white transition-colors"

--- a/frontend/types/session.ts
+++ b/frontend/types/session.ts
@@ -1,4 +1,4 @@
-export type SessionStatus = 'PENDING' | 'RUNNING' | 'PR_OPEN' | 'IN_REVIEW' | 'MERGED';
+export type SessionStatus = 'PENDING' | 'RUNNING' | 'PR_OPEN' | 'IN_REVIEW' | 'MERGED' | 'FAILED';
 
 export type AgentType = 'claude' | 'openai';
 

--- a/src/main/java/com/visa/nucleus/api/SessionController.java
+++ b/src/main/java/com/visa/nucleus/api/SessionController.java
@@ -82,6 +82,18 @@ public class SessionController {
     }
 
     /**
+     * POST /api/sessions/{id}/restore
+     * Restores a FAILED session: recreates the worktree if missing, restarts the
+     * runtime, and re-initializes the agent with fresh issue context.
+     */
+    @PostMapping("/{id}/restore")
+    public ResponseEntity<AgentSession> restoreSession(@PathVariable String id) throws Exception {
+        AgentSession session = orchestratorService.restore(id);
+        broadcast(session);
+        return ResponseEntity.ok(session);
+    }
+
+    /**
      * POST /api/sessions/{id}/message
      * Body: { message }
      * Lets engineers manually send instructions to a running agent.

--- a/src/main/java/com/visa/nucleus/core/plugin/WorkspacePlugin.java
+++ b/src/main/java/com/visa/nucleus/core/plugin/WorkspacePlugin.java
@@ -2,6 +2,7 @@ package com.visa.nucleus.core.plugin;
 
 public interface WorkspacePlugin {
     String createWorktree(String repoPath, String branchName) throws Exception;
+    String restoreWorktree(String repoPath, String branchName) throws Exception;
     void deleteWorktree(String worktreePath) throws Exception;
     String generateBranchName(String ticketId, String ticketTitle);
 }

--- a/src/main/java/com/visa/nucleus/core/service/OrchestratorService.java
+++ b/src/main/java/com/visa/nucleus/core/service/OrchestratorService.java
@@ -8,6 +8,8 @@ import com.visa.nucleus.core.plugin.RuntimePlugin;
 import com.visa.nucleus.core.plugin.TrackerPlugin;
 import com.visa.nucleus.core.plugin.WorkspacePlugin;
 
+import java.io.File;
+
 /**
  * OrchestratorService is the main brain that coordinates all six plugins:
  * TrackerPlugin, WorkspacePlugin, RuntimePlugin, AgentPlugin, NotifierPlugin,
@@ -68,6 +70,7 @@ public class OrchestratorService {
         // 3. Create git worktree
         String branchName = workspacePlugin.generateBranchName(ticketId, projectName);
         String worktreePath = workspacePlugin.createWorktree(repoPath, branchName);
+        session.setBranchName(branchName);
         session.setWorktreePath(worktreePath);
 
         // 4. Update status to RUNNING
@@ -109,6 +112,47 @@ public class OrchestratorService {
         // 3. Mark session as FAILED and save
         session.setStatus(AgentSession.Status.FAILED);
         sessionManager.save(session);
+    }
+
+    /**
+     * Restores a FAILED (or RUNNING) agent session without losing its git branch.
+     *
+     * <ol>
+     *   <li>Fetches the session — must exist and be in FAILED or RUNNING state.</li>
+     *   <li>Recreates the git worktree from the existing branch if the directory is gone.</li>
+     *   <li>Restarts the Docker runtime container.</li>
+     *   <li>Re-fetches issue context from the tracker and re-initializes the agent.</li>
+     *   <li>Sets status back to RUNNING and saves.</li>
+     * </ol>
+     *
+     * @return the restored AgentSession in RUNNING state
+     */
+    public AgentSession restore(String sessionId) throws Exception {
+        AgentSession session = sessionManager.getSession(sessionId)
+                .orElseThrow(() -> new IllegalArgumentException("Session not found: " + sessionId));
+
+        if (session.getStatus() != AgentSession.Status.FAILED
+                && session.getStatus() != AgentSession.Status.RUNNING) {
+            throw new IllegalStateException(
+                    "Session " + sessionId + " cannot be restored from status: " + session.getStatus());
+        }
+
+        // Recreate worktree if missing
+        if (session.getWorktreePath() == null || !new File(session.getWorktreePath()).exists()) {
+            String path = workspacePlugin.restoreWorktree(repoPath, session.getBranchName());
+            session.setWorktreePath(path);
+        }
+
+        // Restart runtime
+        runtimePlugin.start(session);
+
+        // Re-fetch issue context and re-initialize agent
+        String issueContext = trackerPlugin.getIssueContext(session.getTicketId());
+        agentPlugin.initialize(session, issueContext);
+
+        session.setStatus(AgentSession.Status.RUNNING);
+        sessionManager.save(session);
+        return session;
     }
 
     /**

--- a/src/main/java/com/visa/nucleus/plugins/workspace/GitWorktreePlugin.java
+++ b/src/main/java/com/visa/nucleus/plugins/workspace/GitWorktreePlugin.java
@@ -36,6 +36,21 @@ public class GitWorktreePlugin implements WorkspacePlugin {
     }
 
     @Override
+    public String restoreWorktree(String repoPath, String branchName) throws Exception {
+        File worktreeBase = new File(WORKTREE_BASE);
+        if (!worktreeBase.exists()) {
+            worktreeBase.mkdirs();
+        }
+
+        String worktreePath = WORKTREE_BASE + branchName;
+        processRunner.run(
+            List.of("git", "worktree", "add", worktreePath, branchName),
+            repoPath
+        );
+        return worktreePath;
+    }
+
+    @Override
     public void deleteWorktree(String worktreePath) throws Exception {
         // Use the parent repo path — git worktree remove can be run from any git dir.
         // We derive the repo by walking up from the worktree path, but since the

--- a/src/test/java/com/visa/nucleus/api/SessionControllerTest.java
+++ b/src/test/java/com/visa/nucleus/api/SessionControllerTest.java
@@ -185,4 +185,32 @@ class SessionControllerTest {
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
         verifyNoInteractions(runtimePlugin);
     }
+
+    // ------------------------------------------------------------------
+    // POST /api/sessions/{id}/restore
+    // ------------------------------------------------------------------
+
+    @Test
+    void restoreSession_returnsRestoredSessionAndBroadcasts() throws Exception {
+        AgentSession session = new AgentSession("proj", "PROJ-99");
+        session.setStatus(AgentSession.Status.RUNNING);
+        when(orchestratorService.restore(session.getSessionId())).thenReturn(session);
+
+        ResponseEntity<AgentSession> response = controller.restoreSession(session.getSessionId());
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(session.getSessionId(), response.getBody().getSessionId());
+
+        verify(orchestratorService).restore(session.getSessionId());
+        verify(messagingTemplate).convertAndSend(eq("/topic/sessions"), eq(session));
+    }
+
+    @Test
+    void restoreSession_propagatesExceptionFromOrchestrator() throws Exception {
+        when(orchestratorService.restore("bad-id"))
+                .thenThrow(new IllegalArgumentException("Session not found: bad-id"));
+
+        assertThrows(IllegalArgumentException.class, () -> controller.restoreSession("bad-id"));
+    }
 }

--- a/src/test/java/com/visa/nucleus/core/service/OrchestratorServiceTest.java
+++ b/src/test/java/com/visa/nucleus/core/service/OrchestratorServiceTest.java
@@ -150,4 +150,47 @@ class OrchestratorServiceTest {
         assertThrows(IllegalArgumentException.class,
                 () -> orchestrator.handleReviewComment("unknown-id", "comment"));
     }
+
+    // ------------------------------------------------------------------
+    // restore
+    // ------------------------------------------------------------------
+
+    @Test
+    void restore_recreates_worktree_and_restarts_agent() throws Exception {
+        // Build a FAILED session directly (no spawn) so mock interaction counts are clean
+        AgentSession session = new AgentSession("proj", "T-10");
+        session.setStatus(AgentSession.Status.FAILED);
+        session.setBranchName("feat/branch");
+        session.setWorktreePath(null); // worktree is gone
+        sessionManager.save(session);
+
+        when(trackerPlugin.getIssueContext("T-10")).thenReturn("fresh context");
+        when(workspacePlugin.restoreWorktree("/repo", "feat/branch")).thenReturn("/tmp/wt/feat/branch");
+
+        AgentSession restored = orchestrator.restore(session.getSessionId());
+
+        assertEquals(AgentSession.Status.RUNNING, restored.getStatus());
+        assertEquals("feat/branch", restored.getBranchName());
+        verify(workspacePlugin).restoreWorktree("/repo", "feat/branch");
+        verify(runtimePlugin).start(restored);
+        verify(agentPlugin).initialize(restored, "fresh context");
+    }
+
+    @Test
+    void restore_throws_for_unknown_session() {
+        assertThrows(IllegalArgumentException.class, () -> orchestrator.restore("no-such-id"));
+    }
+
+    @Test
+    void restore_throws_for_session_in_non_restoreable_state() throws Exception {
+        when(trackerPlugin.getIssueContext(anyString())).thenReturn("ctx");
+        when(workspacePlugin.generateBranchName(anyString(), anyString())).thenReturn("feat/branch");
+        when(workspacePlugin.createWorktree(anyString(), anyString())).thenReturn("/tmp/wt");
+
+        AgentSession session = orchestrator.spawn("proj", "T-12");
+        session.setStatus(AgentSession.Status.MERGED);
+        sessionManager.save(session);
+
+        assertThrows(IllegalStateException.class, () -> orchestrator.restore(session.getSessionId()));
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `POST /api/sessions/{id}/restore` endpoint to revive FAILED (or RUNNING) sessions without losing their git branch
- Adds `OrchestratorService.restore()` that recreates a missing worktree from the existing branch, restarts the Docker runtime, and re-initializes the agent with fresh issue context
- Adds `WorkspacePlugin.restoreWorktree()` / `GitWorktreePlugin` implementation (`git worktree add` without `-b`, so the existing branch is reused)
- Fixes `OrchestratorService.spawn()` to persist `branchName` on the session (was missing, required for restore)
- Adds a **FAILED** column to the frontend Kanban board
- Adds a **Restore** button on `SessionCard` when `session.status === 'FAILED'`; on click it calls the restore endpoint and the WebSocket broadcast automatically refreshes the card

## Test plan

- [x] All 102 existing + new unit tests pass (`mvn test`)
- [x] `OrchestratorServiceTest` — 3 new tests: restore recreates worktree & restarts agent, throws for unknown session, throws for non-restorable state
- [x] `SessionControllerTest` — 2 new tests: restore returns 200 + broadcasts, propagates exception from orchestrator
- [ ] Manual: mark a session FAILED → click Restore → session moves back to RUNNING column

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)