### PR TITLE
fix: remove duplicate docker-java dependencies with hardcoded versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,18 +83,6 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
 
-        <!-- Docker Java client -->
-        <dependency>
-            <groupId>com.github.docker-java</groupId>
-            <artifactId>docker-java</artifactId>
-            <version>3.3.4</version>
-        </dependency>
-        <dependency>
-            <groupId>com.github.docker-java</groupId>
-            <artifactId>docker-java-transport-httpclient5</artifactId>
-            <version>3.3.4</version>
-        </dependency>
-
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Summary
- Removes the second `docker-java` and `docker-java-transport-httpclient5` dependency declarations that hardcoded version `3.3.4`
- Keeps only the version-property-driven declarations using `${docker-java.version}`
- Ensures `docker-java.version` in `<properties>` is the single source of truth for the Docker client version

## Why
Maven resolves duplicate dependencies by last-declaration-wins. The second block silently overrode `${docker-java.version}` with hardcoded `3.3.4`, meaning any future update to the property would have no effect.

## Test plan
- [ ] Verify `mvn dependency:tree` shows a single version of `docker-java` artifacts
- [ ] Confirm changing `docker-java.version` property now correctly affects the resolved version

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)