### PR TITLE
fix: inject AgentPluginFactory and RuntimePluginFactory into OrchestratorService

### DIFF
--- a/src/main/java/com/visa/nucleus/core/service/OrchestratorService.java
+++ b/src/main/java/com/visa/nucleus/core/service/OrchestratorService.java
@@ -13,6 +13,7 @@ import com.visa.nucleus.core.plugin.TrackerPlugin;
 import com.visa.nucleus.core.plugin.WorkspacePlugin;
 import com.visa.nucleus.plugins.agent.AgentPluginFactory;
 import com.visa.nucleus.plugins.runtime.RuntimePluginFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.io.File;
@@ -34,8 +35,8 @@ public class OrchestratorService {
     private final ProjectService projectService;
     private final TrackerPlugin trackerPlugin;
     private final WorkspacePlugin workspacePlugin;
-    private final RuntimePlugin runtimePlugin;
-    private final AgentPlugin agentPlugin;
+    private final AgentPluginFactory agentPluginFactory;
+    private final RuntimePluginFactory runtimePluginFactory;
     private final List<NotifierPlugin> notifierPlugins;
     private final NucleusProperties nucleusProperties;
 
@@ -44,8 +45,8 @@ public class OrchestratorService {
             ProjectService projectService,
             TrackerPlugin trackerPlugin,
             WorkspacePlugin workspacePlugin,
-            RuntimePlugin runtimePlugin,
-            AgentPlugin agentPlugin,
+            AgentPluginFactory agentPluginFactory,
+            RuntimePluginFactory runtimePluginFactory,
             List<NotifierPlugin> notifierPlugins,
             NucleusProperties nucleusProperties,
             @Value("${NUCLEUS_REPO_PATH:/tmp}") String repoPath) {
@@ -53,8 +54,8 @@ public class OrchestratorService {
         this.projectService = projectService;
         this.trackerPlugin = trackerPlugin;
         this.workspacePlugin = workspacePlugin;
-        this.runtimePlugin = runtimePlugin;
-        this.agentPlugin = agentPlugin;
+        this.agentPluginFactory = agentPluginFactory;
+        this.runtimePluginFactory = runtimePluginFactory;
         this.notifierPlugins = notifierPlugins;
         this.nucleusProperties = nucleusProperties;
     }
@@ -179,6 +180,32 @@ public class OrchestratorService {
 
         session.setStatus(AgentSession.Status.RUNNING);
         sessionManager.save(session);
+    }
+
+    public AgentPlugin agentPluginForSession(String sessionId) throws Exception {
+        AgentSession session = sessionManager.getSession(sessionId)
+                .orElseThrow(() -> new IllegalArgumentException("Session not found: " + sessionId));
+        return agentPluginFactory.create(resolveAgentType(session));
+    }
+
+    public RuntimePlugin runtimePluginForSession(String sessionId) throws Exception {
+        AgentSession session = sessionManager.getSession(sessionId)
+                .orElseThrow(() -> new IllegalArgumentException("Session not found: " + sessionId));
+        return runtimePluginFactory.create(resolveRuntime(session));
+    }
+
+    private String resolveAgentType(AgentSession session) {
+        Project project = projectService.getProject(session.getProjectName()).orElse(null);
+        if (project != null && project.getAgentType() != null) return project.getAgentType();
+        String def = nucleusProperties.getDefaults().getAgent();
+        return def != null ? def : DEFAULT_AGENT_TYPE;
+    }
+
+    private String resolveRuntime(AgentSession session) {
+        Project project = projectService.getProject(session.getProjectName()).orElse(null);
+        if (project != null && project.getRuntime() != null) return project.getRuntime();
+        String def = nucleusProperties.getDefaults().getRuntime();
+        return def != null ? def : DEFAULT_RUNTIME;
     }
 
     private void notifyAll(String sessionId, String message, NotificationLevel level) throws Exception {

--- a/src/test/java/com/visa/nucleus/core/service/OrchestratorServiceTest.java
+++ b/src/test/java/com/visa/nucleus/core/service/OrchestratorServiceTest.java
@@ -25,8 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import java.util.List;
-
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -60,10 +58,18 @@ class OrchestratorServiceTest {
         when(sessionRepository.findById(anyString())).thenAnswer(inv ->
                 Optional.ofNullable(store.get((String) inv.getArgument(0))));
 
+        NucleusProperties.Defaults defaults = new NucleusProperties.Defaults();
+        when(nucleusProperties.getDefaults()).thenReturn(defaults);
+        when(nucleusProperties.getReactions()).thenReturn(new HashMap<>());
+
+        when(agentPluginFactory.create(anyString())).thenReturn(agentPlugin);
+        when(runtimePluginFactory.create(anyString())).thenReturn(runtimePlugin);
+
         sessionManager = new SessionManager(sessionRepository);
         orchestrator = new OrchestratorService(
-                sessionManager, trackerPlugin, workspacePlugin,
-                runtimePlugin, agentPlugin, List.of(notifierPlugin), nucleusProperties, "/repo");
+                sessionManager, projectService, trackerPlugin, workspacePlugin,
+                agentPluginFactory, runtimePluginFactory, List.of(notifierPlugin),
+                nucleusProperties, "/repo");
     }
 
     @Test
@@ -235,5 +241,16 @@ class OrchestratorServiceTest {
         sessionManager.save(session);
 
         assertThrows(IllegalStateException.class, () -> orchestrator.restore(session.getSessionId()));
+    }
+
+    // ------------------------------------------------------------------
+    // helpers
+    // ------------------------------------------------------------------
+
+    private Project project(String name) {
+        Project p = new Project();
+        p.setName(name);
+        p.setPath("/repo");
+        return p;
     }
 }


### PR DESCRIPTION
## Summary

- Replaces singleton `AgentPlugin`/`RuntimePlugin` constructor params with `AgentPluginFactory` and `RuntimePluginFactory` fields, fixing 14 compilation errors
- Implements `resolveAgentType(AgentSession)` and `resolveRuntime(AgentSession)` private helpers that look up project config and fall back to nucleus defaults
- Adds `agentPluginForSession` and `runtimePluginForSession` public helpers required by `SessionController`
- Updates `OrchestratorServiceTest` to use the new constructor signature, configure factory mocks, and add the missing `project()` helper

Closes #52

## Test plan

- [x] `mvn compile` — no errors
- [x] `OrchestratorServiceTest` — 13/13 pass
- [x] Full `mvn test` — 220/220 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)