### PR TITLE
fix: replace single notifierPlugin bean with per-notifier conditional beans

### DIFF
--- a/src/main/java/com/visa/nucleus/config/PluginConfig.java
+++ b/src/main/java/com/visa/nucleus/config/PluginConfig.java
@@ -3,10 +3,13 @@ package com.visa.nucleus.config;
 import com.visa.nucleus.core.plugin.NotifierPlugin;
 import com.visa.nucleus.core.plugin.TrackerPlugin;
 import com.visa.nucleus.core.plugin.WorkspacePlugin;
+import com.visa.nucleus.plugins.notifier.DesktopNotifierPlugin;
+import com.visa.nucleus.plugins.notifier.SlackNotifierPlugin;
 import com.visa.nucleus.plugins.notifier.TeamsNotifierPlugin;
 import com.visa.nucleus.plugins.tracker.JiraTrackerPlugin;
 import com.visa.nucleus.plugins.workspace.GitWorktreePlugin;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
@@ -32,8 +35,22 @@ public class PluginConfig {
     }
 
     @Bean
-    public NotifierPlugin notifierPlugin() {
-        return new TeamsNotifierPlugin();
+    public NotifierPlugin teamsNotifierPlugin(
+            @Value("${TEAMS_WEBHOOK_URL:}") String webhookUrl) {
+        return new TeamsNotifierPlugin(webhookUrl);
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "nucleus.notifiers.slack.enabled", havingValue = "true")
+    public NotifierPlugin slackNotifierPlugin(
+            @Value("${SLACK_WEBHOOK_URL:}") String webhookUrl) {
+        return new SlackNotifierPlugin(webhookUrl);
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "nucleus.notifiers.desktop.enabled", havingValue = "true")
+    public NotifierPlugin desktopNotifierPlugin() {
+        return new DesktopNotifierPlugin();
     }
 
     @Bean

--- a/src/main/java/com/visa/nucleus/plugins/notifier/SlackNotifierPlugin.java
+++ b/src/main/java/com/visa/nucleus/plugins/notifier/SlackNotifierPlugin.java
@@ -34,6 +34,10 @@ public class SlackNotifierPlugin implements NotifierPlugin {
         );
     }
 
+    public SlackNotifierPlugin(String webhookUrl) {
+        this(webhookUrl, null, null, HttpClient.newHttpClient());
+    }
+
     // Package-private constructor for testing
     SlackNotifierPlugin(String webhookUrl, String botToken, String channel, HttpClient httpClient) {
         this.webhookUrl = webhookUrl;

--- a/src/main/java/com/visa/nucleus/plugins/notifier/TeamsNotifierPlugin.java
+++ b/src/main/java/com/visa/nucleus/plugins/notifier/TeamsNotifierPlugin.java
@@ -25,6 +25,10 @@ public class TeamsNotifierPlugin implements NotifierPlugin {
         this(System.getenv("TEAMS_WEBHOOK_URL"), HttpClient.newHttpClient());
     }
 
+    public TeamsNotifierPlugin(String webhookUrl) {
+        this(webhookUrl, HttpClient.newHttpClient());
+    }
+
     // Package-private constructor for testing
     TeamsNotifierPlugin(String webhookUrl, HttpClient httpClient) {
         this.webhookUrl = webhookUrl;

--- a/src/main/resources/agent-orchestrator.yaml
+++ b/src/main/resources/agent-orchestrator.yaml
@@ -1,3 +1,8 @@
 nucleus:
   defaults:
-    notifiers: [slack, desktop]   # can have multiple: teams, slack, desktop
+    notifiers: [teams, slack]     # can have multiple: teams, slack, desktop
+  notifiers:
+    slack:
+      enabled: true
+    desktop:
+      enabled: false


### PR DESCRIPTION
## Summary

- Replaces the single `notifierPlugin()` bean in `PluginConfig` with three separate named beans (`teamsNotifierPlugin`, `slackNotifierPlugin`, `desktopNotifierPlugin`)
- Teams bean is always registered; Slack and Desktop are guarded by `@ConditionalOnProperty` so they only activate when enabled in config
- Adds a `public TeamsNotifierPlugin(String webhookUrl)` and `public SlackNotifierPlugin(String webhookUrl)` constructor to support Spring `@Value` injection
- Updates `src/main/resources/agent-orchestrator.yaml` with `nucleus.notifiers.slack.enabled` and `nucleus.notifiers.desktop.enabled` properties

Spring will now auto-collect all active `NotifierPlugin` beans into the `List<NotifierPlugin>` injected by `OrchestratorService`, and `notifyAll()` broadcasts to every enabled notifier.

Closes #55

## Test plan
- [ ] Application starts without errors when only Teams is configured
- [ ] Setting `nucleus.notifiers.slack.enabled=true` causes Slack bean to appear in the list
- [ ] Setting `nucleus.notifiers.desktop.enabled=true` causes Desktop bean to appear in the list
- [ ] `OrchestratorService.notifyAll()` broadcasts to all registered notifiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)