### PR TITLE
feat: implement TmuxRuntimePlugin — wire tmux runtime into factory (#56)

### DIFF
--- a/src/main/java/com/visa/nucleus/plugins/runtime/DockerRuntimePlugin.java
+++ b/src/main/java/com/visa/nucleus/plugins/runtime/DockerRuntimePlugin.java
@@ -14,6 +14,7 @@ import com.github.dockerjava.core.DefaultDockerClientConfig;
 import com.github.dockerjava.core.DockerClientBuilder;
 import com.visa.nucleus.core.AgentSession;
 import com.visa.nucleus.core.plugin.RuntimePlugin;
+import org.springframework.stereotype.Component;
 
 import java.util.Collections;
 import java.util.List;
@@ -24,6 +25,7 @@ import java.util.List;
  * Each agent session runs in a container named nucleus-agent-{sessionId}
  * with the session's worktree bind-mounted at /workspace.
  */
+@Component
 public class DockerRuntimePlugin implements RuntimePlugin {
 
     static final String IMAGE = "node:20-slim";

--- a/src/main/java/com/visa/nucleus/plugins/runtime/RuntimePluginFactory.java
+++ b/src/main/java/com/visa/nucleus/plugins/runtime/RuntimePluginFactory.java
@@ -14,9 +14,11 @@ import org.springframework.stereotype.Component;
 public class RuntimePluginFactory {
 
     private final DockerRuntimePlugin dockerPlugin;
+    private final TmuxRuntimePlugin tmuxPlugin;
 
-    public RuntimePluginFactory() {
-        this.dockerPlugin = new DockerRuntimePlugin();
+    public RuntimePluginFactory(DockerRuntimePlugin dockerPlugin, TmuxRuntimePlugin tmuxPlugin) {
+        this.dockerPlugin = dockerPlugin;
+        this.tmuxPlugin = tmuxPlugin;
     }
 
     /**
@@ -27,8 +29,7 @@ public class RuntimePluginFactory {
      */
     public RuntimePlugin create(String runtime) {
         if ("tmux".equalsIgnoreCase(runtime)) {
-            // Tmux support is not yet implemented; fall back to Docker
-            return dockerPlugin;
+            return tmuxPlugin;
         }
         // Default: docker
         return dockerPlugin;

--- a/src/main/java/com/visa/nucleus/plugins/runtime/TmuxRuntimePlugin.java
+++ b/src/main/java/com/visa/nucleus/plugins/runtime/TmuxRuntimePlugin.java
@@ -3,6 +3,7 @@ package com.visa.nucleus.plugins.runtime;
 import com.visa.nucleus.core.AgentSession;
 import com.visa.nucleus.core.plugin.RuntimePlugin;
 import com.visa.nucleus.plugins.workspace.ProcessRunner;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -13,6 +14,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * Each agent session runs in a tmux session named nucleus-{sessionId}
  * with the session's worktree as the working directory.
  */
+@Component
 public class TmuxRuntimePlugin implements RuntimePlugin {
 
     static final String SESSION_PREFIX = "nucleus-";

--- a/src/test/java/com/visa/nucleus/plugins/runtime/RuntimePluginFactoryTest.java
+++ b/src/test/java/com/visa/nucleus/plugins/runtime/RuntimePluginFactoryTest.java
@@ -1,0 +1,52 @@
+package com.visa.nucleus.plugins.runtime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class RuntimePluginFactoryTest {
+
+    @Mock
+    private DockerRuntimePlugin dockerPlugin;
+
+    @Mock
+    private TmuxRuntimePlugin tmuxPlugin;
+
+    private RuntimePluginFactory factory;
+
+    @BeforeEach
+    void setUp() {
+        factory = new RuntimePluginFactory(dockerPlugin, tmuxPlugin);
+    }
+
+    @Test
+    void create_returnsTmuxPluginForTmuxRuntime() {
+        assertThat(factory.create("tmux")).isSameAs(tmuxPlugin);
+    }
+
+    @Test
+    void create_returnsTmuxPluginCaseInsensitive() {
+        assertThat(factory.create("TMUX")).isSameAs(tmuxPlugin);
+        assertThat(factory.create("Tmux")).isSameAs(tmuxPlugin);
+    }
+
+    @Test
+    void create_returnsDockerPluginForDockerRuntime() {
+        assertThat(factory.create("docker")).isSameAs(dockerPlugin);
+    }
+
+    @Test
+    void create_returnsDockerPluginForUnrecognizedRuntime() {
+        assertThat(factory.create("kubernetes")).isSameAs(dockerPlugin);
+    }
+
+    @Test
+    void create_returnsDockerPluginForNullRuntime() {
+        assertThat(factory.create(null)).isSameAs(dockerPlugin);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `@Component` to `TmuxRuntimePlugin` so Spring manages it as a singleton bean
- Add `@Component` to `DockerRuntimePlugin` for consistent Spring injection
- Update `RuntimePluginFactory` to accept both plugins via constructor injection and return `TmuxRuntimePlugin` when `runtime: tmux` is configured (previously silently fell back to Docker)
- Fix pre-existing compilation errors in `OrchestratorService`: replace direct `RuntimePlugin`/`AgentPlugin` fields with `RuntimePluginFactory`/`AgentPluginFactory`, add `resolveRuntime`/`resolveAgentType` helpers, add `agentPluginForSession`/`runtimePluginForSession` public methods used by `SessionController`, fix missing `@Value` import
- Add `RuntimePluginFactoryTest` covering tmux/docker/null/unknown runtime dispatch
- Update `OrchestratorServiceTest`: fix stale constructor call, add missing `project()` helper, wire factory mocks correctly

## Test plan

- [x] `RuntimePluginFactoryTest` — 5 tests covering all dispatch branches
- [x] `TmuxRuntimePluginTest` — 14 existing tests, all pass
- [x] `OrchestratorServiceTest` — 13 tests, all pass
- [x] Full test suite: 225 tests, 0 failures

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)