### PR TITLE
fix: remove duplicate docker-java dependencies with hardcoded versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,18 +83,6 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
 
-        <!-- Docker Java client -->
-        <dependency>
-            <groupId>com.github.docker-java</groupId>
-            <artifactId>docker-java</artifactId>
-            <version>3.3.4</version>
-        </dependency>
-        <dependency>
-            <groupId>com.github.docker-java</groupId>
-            <artifactId>docker-java-transport-httpclient5</artifactId>
-            <version>3.3.4</version>
-        </dependency>
-
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Summary
- Removes duplicate `docker-java` and `docker-java-transport-httpclient5` dependency declarations that had hardcoded version `3.3.4`
- Keeps only the version-property-driven declarations using `${docker-java.version}`
- `${docker-java.version}` is now the single source of truth for the Docker client version

Closes #58

## Test plan
- [ ] Verify `mvn dependency:tree` shows no duplicate docker-java artifacts
- [ ] Verify build succeeds with `mvn compile`
- [ ] Verify updating `docker-java.version` property now correctly controls the version used

🤖 Generated with [Claude Code](https://claude.com/claude-code)